### PR TITLE
Fix config override behavior to update rather than replace default

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -173,6 +173,21 @@ The cascade is performed using a breadth-first search. If
 `function.start.DEBUG` is not defined, check `start.DEBUG` then check
 `function.start` *BEFORE* checking `start`.
 
+The default configuration is:
+
+.. code-block:: python
+
+    DEFAULT_TEMPLATES = {
+        'start': 'Enter {label}',
+        'finish': 'Exit {label}',
+        'function.start': 'Call `{label}({arguments})`',
+        'function.finish': 'Return from `{label}`',
+    }
+
+Note that custom configuration *updates* these defaults. For example, if you
+want to if you want to skip logging on exit for all context managers and
+decorators, you'll have set *both* `'finish'` and `'function.finish'` to an
+a `None` or an empty string.
 
 Credits
 -------

--- a/logquacious/context_templates.py
+++ b/logquacious/context_templates.py
@@ -62,8 +62,8 @@ DEFAULT_TEMPLATES = {
 class ContextTemplates(CascadingConfig):
 
     def __init__(self, config_dict=None):
-        config_dict = config_dict or DEFAULT_TEMPLATES
-        config_dict = config_dict.copy()
+        config_dict, additional_config = DEFAULT_TEMPLATES.copy(), config_dict
+        config_dict.update(additional_config or {})
         config_dict.setdefault('start', DEFAULT_TEMPLATES['start'])
         config_dict.setdefault('finish', DEFAULT_TEMPLATES['finish'])
         self._warn_if_given_unknown_keys(config_dict.keys())

--- a/logquacious/tests/test_context_templates.py
+++ b/logquacious/tests/test_context_templates.py
@@ -5,7 +5,7 @@ import pytest
 
 from logquacious import constants, context_templates
 from logquacious.context_templates import DEFAULT_TEMPLATES, ContextTemplates
-from utils import StartsWith
+from utils import StartsWith, assert_dict_match
 
 
 CONTEXT_TYPES = ['function', 'context']
@@ -49,12 +49,14 @@ class TestContextTemplates:
     def test_config_missing_start(self):
         templates = ContextTemplates({'finish': 'custom'})
         assert templates['finish'] == 'custom'
-        assert templates['start'] == DEFAULT_TEMPLATES['start']
+        assert_dict_match(templates, DEFAULT_TEMPLATES,
+                          ['start', 'function.start', 'function.finish'])
 
     def test_config_missing_finish(self):
         templates = ContextTemplates({'start': 'custom'})
         assert templates['start'] == 'custom'
-        assert templates['finish'] == DEFAULT_TEMPLATES['finish']
+        assert_dict_match(templates, DEFAULT_TEMPLATES,
+                          ['finish', 'function.start', 'function.finish'])
 
     def test_null_config(self):
         config = ContextTemplates()
@@ -78,6 +80,8 @@ class TestMinimalContextTemplates:
         self.config = ContextTemplates({
             'start': self.start_text,
             'finish': self.finish_text,
+            'function.start': self.start_text,
+            'function.finish': self.finish_text,
         })
 
     @pytest.mark.parametrize('key', START_KEYS)

--- a/logquacious/tests/utils.py
+++ b/logquacious/tests/utils.py
@@ -7,3 +7,12 @@ class StartsWith(str):
         if is_string(other):
             return other.startswith(self)
         return False
+
+
+def assert_dict_match(actual, expected, keys=None):
+    if keys is None:
+        assert actual.keys() == expected.keys()
+        keys = actual.keys()
+
+    for k in keys:
+        assert actual[k] == expected[k]


### PR DESCRIPTION
Previously, configuring context templates would completely replace the default configuration. The behavior is now changed to _extend_ the default configuration