### PR TITLE
Report context of code calling logging utilities using `stacklevel`

### DIFF
--- a/logquacious/backport_configurable_stacklevel.py
+++ b/logquacious/backport_configurable_stacklevel.py
@@ -139,6 +139,11 @@ class ConfigurableStacklevelLoggerMixin(object):
                 exc_info = (type(exc_info), exc_info, exc_info.__traceback__)
             elif not isinstance(exc_info, tuple):
                 exc_info = sys.exc_info()
-        record = self.makeRecord(self.name, level, fn, lno, msg, args,
-                                 exc_info, func, extra, sinfo)
+
+        if sys.version_info.major >= 3:
+            record = self.makeRecord(self.name, level, fn, lno, msg, args,
+                                     exc_info, func, extra, sinfo)
+        else:
+            record = self.makeRecord(self.name, level, fn, lno, msg, args,
+                                     exc_info, func, extra)
         self.handle(record)

--- a/logquacious/backport_configurable_stacklevel.py
+++ b/logquacious/backport_configurable_stacklevel.py
@@ -81,7 +81,7 @@ class ConfigurableStacklevelLoggerMixin(object):
     See https://github.com/python/cpython/pull/7424
     """
 
-    def findCaller(self, stack_info=False, stacklevel=1):
+    def findCaller(self, stack_info=False, stacklevel=1):  # pragma: no cover
         """
         Find the stack frame of the caller so that we can note the source
         file name, line number and function name.
@@ -118,7 +118,7 @@ class ConfigurableStacklevelLoggerMixin(object):
         return rv
 
     def _log(self, level, msg, args, exc_info=None, extra=None,
-             stack_info=False, stacklevel=1):
+             stack_info=False, stacklevel=1):  # pragma: no cover
         """
         Low-level logging routine which creates a LogRecord and then calls
         all the handlers of this logger to handle the record.
@@ -130,9 +130,9 @@ class ConfigurableStacklevelLoggerMixin(object):
             # IronPython can use logging.
             try:
                 fn, lno, func, sinfo = self.findCaller(stack_info, stacklevel)
-            except ValueError:  # pragma: no cover
+            except ValueError:
                 fn, lno, func = "(unknown file)", 0, "(unknown function)"
-        else:  # pragma: no cover
+        else:
             fn, lno, func = "(unknown file)", 0, "(unknown function)"
         if exc_info:
             if isinstance(exc_info, BaseException):

--- a/logquacious/backport_configurable_stacklevel.py
+++ b/logquacious/backport_configurable_stacklevel.py
@@ -1,0 +1,144 @@
+"""
+Backport of configurable stacklevel for logging added in Python 3.8.
+
+See https://github.com/python/cpython/pull/7424
+"""
+import io
+import logging
+import os
+import sys
+import traceback
+from contextlib import contextmanager
+
+
+__all__ = ['PatchedLoggerMixin', 'patch_logger']
+
+
+class PatchedLoggerMixin(object):
+    """Mixin adding `temp_monkey_patched_logger` that allows stacklevel kwarg.
+
+    Classes that include this mixin have a `temp_monkey_patched_logger`
+    context manager that allows the use of the `stacklevel` keyword argument
+    from Python 3.8.
+
+    Classes using this mixin must have a `logging.Logger` instance as an
+    attribute of the class. By default, this is assumed to be named `logger`,
+    but you can override the `logger_attribute` class attribute with the
+    name of a different attribute.
+    """
+
+    #: Name of logger instance on the class inheriting this mixin.
+    logger_attribute = 'logger'
+
+    def __init__(self, *args, **kwargs):
+        super(PatchedLoggerMixin, self).__init__(*args, **kwargs)
+        self._patched_logger_class = None
+
+    def _get_logger(self):
+        if not hasattr(self, self.logger_attribute):
+            msg = (
+                "Subclass of PatchedLoggerMixin must define `{}` attribute "
+                "or override `logger_attribute`".format(self.logger_attribute)
+            )
+            raise AttributeError(msg)
+        return getattr(self, self.logger_attribute)
+
+    @contextmanager
+    def temp_monkey_patched_logger(self):
+        """Temporarily monkey patch logger to allow overriding log records.
+
+        The monkey patching is reset so that the behavior change is limited
+        to the scope of this logger.
+        """
+        logger = self._get_logger()
+        original_logger_class = logger.__class__
+
+        # Cache patched logger class if not already defined.
+        if self._patched_logger_class is None:
+            self._patched_logger_class = patch_logger(logger.__class__)
+
+        logger.__class__ = self._patched_logger_class
+        try:
+            yield
+        finally:
+            logger.__class__ = original_logger_class
+
+
+def patch_logger(logger_class):
+    """Return logger class patched with stacklevel keyword argument."""
+    if sys.version_info.major >= 3 and sys.version_info.minor >= 8:
+        return logger_class
+    return type('ConfigurableStacklevelLogger',
+                (ConfigurableStacklevelLoggerMixin, logger_class), {})
+
+
+class ConfigurableStacklevelLoggerMixin(object):
+    """Mixin for adding `stacklevel` keyword argument for logging methods.
+
+    This mixin can be used to monkey patch `logging.Logger` to include the
+    `stacklevel` keyword argument that will be available in Python 3.8.
+
+    See https://github.com/python/cpython/pull/7424
+    """
+
+    def findCaller(self, stack_info=False, stacklevel=1):
+        """
+        Find the stack frame of the caller so that we can note the source
+        file name, line number and function name.
+        """
+        f = logging.currentframe()
+        # On some versions of IronPython, currentframe() returns None if
+        # IronPython isn't run with -X:Frames.
+        if f is not None:
+            f = f.f_back
+        orig_f = f
+        while f and stacklevel > 1:
+            f = f.f_back
+            stacklevel -= 1
+        if not f:
+            f = orig_f
+        rv = "(unknown file)", 0, "(unknown function)", None
+        while hasattr(f, "f_code"):
+            co = f.f_code
+            filename = os.path.normcase(co.co_filename)
+            if filename == logging._srcfile:
+                f = f.f_back
+                continue
+            sinfo = None
+            if stack_info:
+                sio = io.StringIO()
+                sio.write('Stack (most recent call last):\n')
+                traceback.print_stack(f, file=sio)
+                sinfo = sio.getvalue()
+                if sinfo[-1] == '\n':
+                    sinfo = sinfo[:-1]
+                sio.close()
+            rv = (co.co_filename, f.f_lineno, co.co_name, sinfo)
+            break
+        return rv
+
+    def _log(self, level, msg, args, exc_info=None, extra=None,
+             stack_info=False, stacklevel=1):
+        """
+        Low-level logging routine which creates a LogRecord and then calls
+        all the handlers of this logger to handle the record.
+        """
+        sinfo = None
+        if logging._srcfile:
+            # IronPython doesn't track Python frames, so findCaller raises an
+            # exception on some versions of IronPython. We trap it here so that
+            # IronPython can use logging.
+            try:
+                fn, lno, func, sinfo = self.findCaller(stack_info, stacklevel)
+            except ValueError:  # pragma: no cover
+                fn, lno, func = "(unknown file)", 0, "(unknown function)"
+        else:  # pragma: no cover
+            fn, lno, func = "(unknown file)", 0, "(unknown function)"
+        if exc_info:
+            if isinstance(exc_info, BaseException):
+                exc_info = (type(exc_info), exc_info, exc_info.__traceback__)
+            elif not isinstance(exc_info, tuple):
+                exc_info = sys.exc_info()
+        record = self.makeRecord(self.name, level, fn, lno, msg, args,
+                                 exc_info, func, extra, sinfo)
+        self.handle(record)

--- a/logquacious/tests/test_backport_configurable_stacklevel.py
+++ b/logquacious/tests/test_backport_configurable_stacklevel.py
@@ -1,0 +1,73 @@
+import logging
+from unittest import TestCase
+
+from logquacious.backport_configurable_stacklevel import PatchedLoggerMixin
+
+
+class RecordingHandler(logging.NullHandler):
+
+    def __init__(self, *args, **kwargs):
+        super(RecordingHandler, self).__init__(*args, **kwargs)
+        self.records = []
+
+    def handle(self, record):
+        """Keep track of all the emitted records."""
+        self.records.append(record)
+
+
+class TestPatchedLoggerMixin(PatchedLoggerMixin, TestCase):
+    """TestCase for PatchedLoggerMixin adapted from cpython logger tests.
+
+    Adapted from `LoggerTest` class of cpython logger tests.
+
+    See https://github.com/python/cpython/blob/master/Lib/test/test_logging.py
+    """
+
+    def setUp(self):
+        self.logger = logging.Logger(name='test')
+        self.recording = RecordingHandler()
+        self.logger.addHandler(self.recording)
+        self.addCleanup(self.logger.removeHandler, self.recording)
+        self.addCleanup(self.recording.close)
+        self.addCleanup(logging.shutdown)
+
+    def test_find_caller_with_stacklevel(self):
+        """Test of PatchedLoggerMixin adapted from cpython logger tests.
+
+        See https://github.com/python/cpython/pull/7424
+        """
+        the_level = 1
+
+        def innermost():
+            with self.temp_monkey_patched_logger():
+                self.logger.warning('test', stacklevel=the_level)
+
+        def inner():
+            innermost()
+
+        def outer():
+            inner()
+
+        records = self.recording.records
+
+        outer()
+        record_1 = records[-1]
+        assert record_1.funcName == 'innermost'
+
+        the_level = 2
+        outer()
+        stacklevel_2 = records[-1]
+        assert stacklevel_2.funcName == 'inner'
+        assert stacklevel_2.lineno > record_1.lineno
+
+        the_level = 3
+        outer()
+        stacklevel_3 = records[-1]
+        assert stacklevel_3.funcName == 'outer'
+        assert stacklevel_3.lineno > stacklevel_2.lineno
+
+        the_level = 4
+        outer()
+        stacklevel_4 = records[-1]
+        assert stacklevel_4.funcName == 'test_find_caller_with_stacklevel'
+        assert stacklevel_4.lineno > stacklevel_3.lineno

--- a/logquacious/tests/test_backport_configurable_stacklevel.py
+++ b/logquacious/tests/test_backport_configurable_stacklevel.py
@@ -1,6 +1,8 @@
 import logging
 from unittest import TestCase
 
+import pytest
+
 from logquacious.backport_configurable_stacklevel import PatchedLoggerMixin
 
 
@@ -15,7 +17,20 @@ class RecordingHandler(logging.NullHandler):
         self.records.append(record)
 
 
-class TestPatchedLoggerMixin(PatchedLoggerMixin, TestCase):
+class TestPatchedLoggerMixin:
+
+    def test_error_raised_if_no_logger_attribute(self):
+
+        class LogManager(PatchedLoggerMixin):
+            pass
+
+        manager = LogManager()
+        with pytest.raises(AttributeError):
+            with manager.temp_monkey_patched_logger():
+                pass
+
+
+class TestPatchedLoggerMixinLogging(PatchedLoggerMixin, TestCase):
     """TestCase for PatchedLoggerMixin adapted from cpython logger tests.
 
     Adapted from `LoggerTest` class of cpython logger tests.

--- a/logquacious/tests/test_context_templates.py
+++ b/logquacious/tests/test_context_templates.py
@@ -123,7 +123,7 @@ class TestLevelSpecificContextTemplates:
 
 
 class TestSecondaryContextTemplates:
-    """Test secondary cascade for context templates.
+    r"""Test secondary cascade for context templates.
 
     For example, consider the cascade pattern for `function.start.DEBUG`.
     which has a cascade graph that looks like::

--- a/logquacious/tests/test_log_context.py
+++ b/logquacious/tests/test_log_context.py
@@ -32,8 +32,8 @@ class TestLogContext:
             pass
 
         self.logger.log.assert_has_calls([
-            mock.call(level, 'Enter context label'),
-            mock.call(level, 'Exit context label'),
+            mock.call(level, 'Enter context label', stacklevel=3),
+            mock.call(level, 'Exit context label', stacklevel=3),
         ])
 
     @func_name_and_level_parameters
@@ -50,8 +50,8 @@ class TestLogContext:
         function()
 
         self.logger.log.assert_has_calls([
-            mock.call(level, 'Call `function()`'),
-            mock.call(level, 'Return from `function`'),
+            mock.call(level, 'Call `function()`', stacklevel=3),
+            mock.call(level, 'Return from `function`', stacklevel=3),
         ])
 
     @func_name_and_level_parameters
@@ -72,8 +72,8 @@ class TestLogContext:
         function('a', b=1)
 
         self.logger.log.assert_has_calls([
-            mock.call(level, "Called `function('a', b=1)`"),
-            mock.call(level, 'Return from `function`'),
+            mock.call(level, "Called `function('a', b=1)`", stacklevel=3),
+            mock.call(level, 'Return from `function`', stacklevel=3),
         ])
 
     @func_name_and_level_parameters
@@ -90,7 +90,7 @@ class TestLogContext:
 
         function()
 
-        self.logger.log.assert_called_once_with(level, "Finish")
+        self.logger.log.assert_called_once_with(level, "Finish", stacklevel=3)
 
     @func_name_and_level_parameters
     def test_null_finish_template_for_decorator(self, func_name, level):
@@ -106,7 +106,7 @@ class TestLogContext:
 
         function()
 
-        self.logger.log.assert_called_once_with(level, "Start")
+        self.logger.log.assert_called_once_with(level, "Start", stacklevel=3)
 
     @func_name_and_level_parameters
     def test_null_start_template_for_context_manager(self, func_name, level):
@@ -120,7 +120,7 @@ class TestLogContext:
         with context_manager('context label'):
             pass
 
-        self.logger.log.assert_called_once_with(level, "Finish")
+        self.logger.log.assert_called_once_with(level, "Finish", stacklevel=3)
 
     @func_name_and_level_parameters
     def test_null_finish_template_for_context_manager(self, func_name, level):
@@ -134,4 +134,4 @@ class TestLogContext:
         with context_manager('context label'):
             pass
 
-        self.logger.log.assert_called_once_with(level, "Start")
+        self.logger.log.assert_called_once_with(level, "Start", stacklevel=3)

--- a/logquacious/tests/test_log_manager.py
+++ b/logquacious/tests/test_log_manager.py
@@ -39,6 +39,7 @@ class TestLogManager:
             logging.ERROR,
             "Suppressed error and logging",
             exc_info=True,
+            stacklevel=3,
         )
 
     def test_log_and_suppress_decorator(self):
@@ -52,6 +53,7 @@ class TestLogManager:
             logging.ERROR,
             "Suppressed error and logging",
             exc_info=True,
+            stacklevel=3,
         )
 
     def test_log_and_reraise_context_manager(self):
@@ -63,6 +65,7 @@ class TestLogManager:
             logging.ERROR,
             "Logging error and reraising",
             exc_info=True,
+            stacklevel=3,
         )
 
     def test_log_and_reraise_decorator(self):
@@ -77,6 +80,7 @@ class TestLogManager:
             logging.ERROR,
             "Logging error and reraising",
             exc_info=True,
+            stacklevel=3,
         )
 
     @pytest.mark.parametrize('method', [


### PR DESCRIPTION
Backport `stacklevel` keyword argument from python 3.8 and configure `stacklevel` on logging statements to reflect the context of where the `logquacious` utilities are called rather than the utilities themselves.

Closes https://github.com/tonysyu/logquacious/issues/7